### PR TITLE
 gh-7163 "Fix: Display weight without trailing zeros" app.py

### DIFF
--- a/issues/gh-7163/app.py
+++ b/issues/gh-7163/app.py
@@ -1,7 +1,11 @@
 import streamlit as st
+
 with st.expander("Weight Loss", expanded=True):
     weight_goal = 200
     initial_weight = 275.0
-    todays_weight = st.number_input("Current Weight", value=initial_weight, min_value=170.0, max_value=280.0, step=0.2, help ="Goal is 200.")
+    todays_weight = col1.number_input("Current Weight", value=initial_weight, min_value=170.0, max_value=280.0, step=0.2, help="Goal is 200.")
 
+# Convert the float to a formatted string without trailing zeros
+formatted_weight = f"{todays_weight:.1f}"  # Display up to 1 decimal place
 
+st.write("Formatted Weight:", formatted_weight)


### PR DESCRIPTION
The behavior you're observing is because the st.number_input widget in Streamlit automatically formats floating-point numbers with two decimal places by default. If you want to change this behavior and display the number without trailing zeros, you can use Python's string formatting functions to achieve that.
formatted_weight is a string that is created using a formatted string literal (f"{todays_weight:.1f}") to display the number with up to 1 decimal place. This way, you can control the number of decimal places displayed and avoid trailing zeros.
![gh-7163](https://github.com/streamlit/st-issues/assets/98071322/3eeb77e5-f56f-4f21-a0f6-fe16a41a5564)
