### PR TITLE
[feat] Add VSCode launch.json for running and debugging apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ target/
 !.vscode/recommended-tasks.json
 !.vscode/recommended-launch.json
 !.vscode/extensions.json
+!.vscode/launch.json
 # Ignore all local history of files
 **/.history
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Streamlit App",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "streamlit",
+      "args": ["run", "${file}"]
+      // allows to set breakpoints in installed packages, such as the Streamlit lib itself or custom component code etc.
+      // "justMyCode": false,
+      // allows to use a different installed version of streamlit in another venv folder, e.g.
+      // "program": "~/Projects/streamlit/lib/venv/bin/pytest"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a simple VSCode `launch.json` file with the ability to run/debug a Streamlit app. Makes for a better dev env

![Screenshot 2025-06-10 at 9 50 51 AM](https://github.com/user-attachments/assets/4e2803cf-0dbb-43bf-81bb-6bb1fa35c0a6)
