### PR TITLE
Enhance debugging prompt template for Streamlit issues

### DIFF
--- a/app/utils/ai/templates/debugging_prompt.j2
+++ b/app/utils/ai/templates/debugging_prompt.j2
@@ -21,7 +21,6 @@ First, review the following information about the reported issue:
 
    {% endfor %}
    {% endif %}
-   {{COMMENTS}}
 </issue_comments>
 
 

--- a/app/utils/ai/templates/debugging_prompt.j2
+++ b/app/utils/ai/templates/debugging_prompt.j2
@@ -42,7 +42,21 @@ Please follow these steps in your analysis:
 7. Explain your reasoning step by step, citing specific parts of the codebase where appropriate.
 
 Before providing your final analysis, work through your debugging process inside <debugging_process> tags within your
-   thinking block. In this section:
+   thinking block. The `<debugging_process>` tags should encapsulate your detailed thought process and analysis. Use the
+   following format as a guide:
+
+   <debugging_process>
+   - Key Symptoms and Behaviors:
+       List out the symptoms and behaviors mentioned in the issue.
+   - Potential Code Paths:
+       Identify specific code paths that could lead to these symptoms.
+   - Hypotheses:
+       Consider multiple hypotheses for the root cause.
+   - Evidence Evaluation:
+       Evaluate each hypothesis based on the available evidence.
+   </debugging_process>
+
+   In this section:
    - List out key symptoms and behaviors mentioned in the issue
    - Identify potential code paths that could lead to these symptoms
    - Consider multiple hypotheses for the root cause

--- a/app/utils/ai/templates/debugging_prompt.j2
+++ b/app/utils/ai/templates/debugging_prompt.j2
@@ -1,32 +1,78 @@
-You are helping me debug an issue in the Streamlit repository. I need your help identifying the most likely root cause of a user-reported issue.
+You are an expert software engineer tasked with debugging a complex issue in the Streamlit repository. Your goal is to
+identify the most likely root cause of a user-reported problem by conducting a thorough analysis of the issue and the
+codebase.
 
-Your task is to deeply analyze the issue description and any available comments, then search through the codebase to identify the most probable cause of the problem. Don't focus on fixing the issue yet, but provide a thorough analysis of what's likely going wrong.
+First, review the following information about the reported issue:
 
-## Issue Title:
-{{ issue_title }}
+<issue_title>
+   {{ issue_title }}
+</issue_title>
 
-## Issue Description:
-{{ issue_body }}
+<issue_description>
+   {{ issue_body }}
+</issue_description>
 
-{% if comments %}
-## Comments:
-{% for comment in comments %}
-**{{ comment.author | default('Unknown') }}** wrote:
-{{ comment.body | default('') }}
+<issue_comments>
+   {% if comments %}
+   ## Comments:
+   {% for comment in comments %}
+   **{{ comment.author | default('Unknown') }}** wrote:
+   {{ comment.body | default('') }}
 
-{% endfor %}
-{% endif %}
+   {% endfor %}
+   {% endif %}
+   {{COMMENTS}}
+</issue_comments>
 
-## Your Task:
-1. Thoroughly analyze the issue description and comments
-2. Identify the specific component(s) of Streamlit that are likely involved
-3. Search through relevant code files to find potential problematic sections
-4. Provide a detailed analysis of what's likely causing the issue, including:
-   - The specific code path that's being triggered
-   - How inputs or state might be causing unexpected behavior
-   - Any edge cases that might not be handled properly
-   - How the observed behavior differs from expected behavior
-5. Consider various factors like browser compatibility, operating system specifics, or version-specific issues
-6. Explain your reasoning step by step, citing specific parts of the codebase where appropriate
 
+Your task is to analyze this information and the Streamlit codebase to determine the most probable cause of the problem.
 Focus on identifying the root cause with high confidence rather than proposing fixes at this stage.
+
+Please follow these steps in your analysis:
+
+1. Thoroughly analyze the issue description and comments.
+2. Identify the specific component(s) of Streamlit that are likely involved.
+3. Search through relevant code files to find potential problematic sections.
+4. Provide a detailed analysis of what's likely causing the issue, including:
+- The specific code path that's being triggered
+- How inputs or state might be causing unexpected behavior
+- Any edge cases that might not be handled properly
+- How the observed behavior differs from expected behavior
+5. Consider various factors like browser compatibility, operating system specifics, or version-specific issues.
+6. Review the git history to identify any recent changes that might have caused this regression.
+7. Explain your reasoning step by step, citing specific parts of the codebase where appropriate.
+
+Before providing your final analysis, work through your debugging process inside <debugging_process> tags within your
+   thinking block. In this section:
+   - List out key symptoms and behaviors mentioned in the issue
+   - Identify potential code paths that could lead to these symptoms
+   - Consider multiple hypotheses for the root cause
+   - Evaluate each hypothesis based on the available evidence
+
+   This is where you should consider multiple pieces of evidence, explore different possibilities, and demonstrate
+   "ultrathinking" about what could be causing the issue. Do not jump to conclusions prematurely; instead, build a
+   comprehensive understanding of the problem before synthesizing your findings. It's OK for this section to be quite
+   long.
+
+   Your final output should be structured as follows:
+
+   1. Initial Assessment
+   2. Component Identification
+   3. Code Analysis
+   4. Potential Causes
+   5. Contributing Factors
+   6. Git History Review
+   7. Conclusion
+
+   In each section, provide detailed explanations and cite specific evidence from the issue description, comments, and
+   codebase to support your analysis.
+
+   Your final output should consist only of the structured analysis and should not duplicate or rehash any of the work
+   you did in the debugging process thinking block.
+
+   You are helping me debug an issue in the Streamlit repository. I need your help identifying the most likely root
+   cause of a user-reported issue.
+
+   Your task is to deeply analyze the issue description and any available comments, then search through the codebase to
+   identify the most probable cause of the problem. Don't focus on fixing the issue yet, but provide a thorough analysis
+   of what's likely going wrong.

--- a/app/utils/ai/templates/debugging_prompt.j2
+++ b/app/utils/ai/templates/debugging_prompt.j2
@@ -82,10 +82,3 @@ Before providing your final analysis, work through your debugging process inside
 
    Your final output should consist only of the structured analysis and should not duplicate or rehash any of the work
    you did in the debugging process thinking block.
-
-   You are helping me debug an issue in the Streamlit repository. I need your help identifying the most likely root
-   cause of a user-reported issue.
-
-   Your task is to deeply analyze the issue description and any available comments, then search through the codebase to
-   identify the most probable cause of the problem. Don't focus on fixing the issue yet, but provide a thorough analysis
-   of what's likely going wrong.

--- a/app/utils/ai/templates/debugging_prompt.j2
+++ b/app/utils/ai/templates/debugging_prompt.j2
@@ -33,10 +33,10 @@ Please follow these steps in your analysis:
 2. Identify the specific component(s) of Streamlit that are likely involved.
 3. Search through relevant code files to find potential problematic sections.
 4. Provide a detailed analysis of what's likely causing the issue, including:
-- The specific code path that's being triggered
-- How inputs or state might be causing unexpected behavior
-- Any edge cases that might not be handled properly
-- How the observed behavior differs from expected behavior
+    - The specific code path that's being triggered
+    - How inputs or state might be causing unexpected behavior
+    - Any edge cases that might not be handled properly
+    - How the observed behavior differs from expected behavior
 5. Consider various factors like browser compatibility, operating system specifics, or version-specific issues.
 6. Review the git history to identify any recent changes that might have caused this regression.
 7. Explain your reasoning step by step, citing specific parts of the codebase where appropriate.


### PR DESCRIPTION
Updated the Jinja2 template for debugging prompts to provide a more structured and detailed analysis process. The template now includes sections for issue title, description, comments, and a comprehensive debugging process, guiding users through a thorough investigation of user-reported issues. This change aims to improve clarity and effectiveness in identifying root causes.


# Cursor Output for #12064 with old prompt (claude-sonnet-4 thinking):
I'll help you analyze this issue systematically. Let me start by investigating the `st.line_chart` implementation and its interaction with Altair.
Search files...

Read file: lib/streamlit/elements/lib/built_in_chart_utils.py

Search files...

Read file: lib/streamlit/type_util.py

Ran tool

Search files...

Ran tool

Search files...

Ran tool

## Root Cause Analysis

After thoroughly analyzing the issue, codebase, and related information, I can identify the most likely root cause of this problem.

### **Primary Root Cause: Altair 5.4.0/5.4.1 Narwhals Compatibility Issue**

The issue stems from a known compatibility problem between **Altair versions 5.4.0 and 5.4.1** and the **narwhals** library dependency. This is confirmed by MarcoGorelli's comment suggesting either excluding these specific Altair versions or upgrading narwhals to version 2.0.1 or higher.

### **Specific Technical Details**

1. **Altair Dependency Specification**: Streamlit 1.46.1 specifies `altair >=4.0, <6` in its setup.py, which allows the problematic Altair versions 5.4.0 and 5.4.1.

2. **The Failing Code Path**: The issue occurs specifically with `st.line_chart` when using the newer parameter syntax introduced in Altair 5.x:
   ```python
   st.line_chart(
       chart_data,
       x="col1",
       y=["col2", "col3"],
       color=["#FF0000", "#0000FF"],
   )
   ```

3. **The Altair Selection API Dependency**: Looking at the code in `lib/streamlit/elements/lib/built_in_chart_utils.py`, there are two critical features that depend on Altair 5.0.0+:

   **Lines 283-288**: Enhanced hover tooltips for line charts:
   ```python
   if (
       chart_type is ChartType.LINE
       and x_column is not None
       # This is using the new selection API that was added in Altair 5.0.0
       and is_altair_version_5_or_greater
   ):
       return _add_improved_hover_tooltips(
           chart, x_column, width, height
       ).interactive(), add_rows_metadata
   ```

   **Lines 301-307**: Uses `alt.selection_point()` which is the new API:
   ```python
   nearest = alt.selection_point(
       nearest=True,
       on="pointerover",
       fields=[x_column],
       empty=False,
       clear="pointerout",
   )
   ```

4. **The Narwhals Breakdown**: Altair 5.4.0 and 5.4.1 introduced a dependency on narwhals for dataframe compatibility, but these specific versions had bugs in their narwhals integration that caused the selection API to fail when generating the Vega-Lite specification.

### **Why This Only Affects Certain Streamlit Versions**

- **Streamlit ≤ 1.34.0**: Works because it may have used different chart generation logic or handled the Altair errors more gracefully
- **Streamlit > 1.34.0**: Fails because newer versions rely more heavily on the Altair 5.x selection API and parameter binding features, which trigger the narwhals compatibility bugs

### **The Error Chain**

1. User calls `st.line_chart()` with `x`, `y`, and `color` parameters
2. Streamlit's `generate_chart()` function processes these parameters
3. When `chart_type is ChartType.LINE` and Altair ≥ 5.0.0, it calls `_add_improved_hover_tooltips()`
4. This function uses `alt.selection_point()` which internally relies on narwhals
5. Due to the bug in Altair 5.4.0/5.4.1's narwhals integration, the chart generation fails
6. The error manifests as an empty chart initially, then shows "Unrecognized signal name" errors

### **Why the Suggested Solutions Work**

- **Excluding Altair 5.4.0 and 5.4.1**: Avoids the buggy versions entirely
- **Setting `narwhals>=2.0.1`**: Provides a fixed version of narwhals that resolves the compatibility issues
- **Upgrading to newer Altair versions**: Later versions (5.4.2+) fixed the narwhals integration bugs

### **Conclusion**

This is a classic dependency compatibility issue where Streamlit's broader dependency constraints (`altair >=4.0, <6`) inadvertently allow problematic Altair versions that have known bugs in their narwhals integration. The issue specifically manifests in Streamlit's enhanced line chart functionality that leverages Altair 5.x's new selection API features.

The solution requires either tightening Streamlit's Altair dependency constraints to exclude the problematic versions, or ensuring narwhals is upgraded to a compatible version.


---------

# Cursor output for the same issue with the same model but new prompt

I'll conduct a thorough analysis of this issue by examining the codebase and understanding the dependency relationships. Let me start by exploring the relevant components.
Search files...

Ran tool
Ran tool

Ran tool
Ran tool

Search files...
Ran tool

Search files...
Ran tool

Read file: lib/setup.py

Based on my thorough analysis of the issue, codebase, and recent changes, I've identified the root cause of this problem. Let me provide a structured analysis:

## 1. Initial Assessment

This is a **dependency compatibility issue** between specific Altair versions (5.4.0 and 5.4.1) and the narwhals library. The issue manifests when users have a "valid" package combination according to Streamlit's dependency specifications, but the underlying dependency interaction causes chart rendering failures.

## 2. Component Identification

The affected components are:
- **Primary**: `st.line_chart` function in `lib/streamlit/elements/vega_charts.py`
- **Secondary**: The chart generation pipeline through `generate_chart` in `lib/streamlit/elements/lib/built_in_chart_utils.py`
- **Root cause**: Dependency resolution between Altair and narwhals libraries

## 3. Code Analysis

From the codebase analysis, I found that:

```12:15:lib/streamlit/elements/vega_charts.py
# st.line_chart calls generate_chart and passes result to _altair_chart
chart, add_rows_metadata = generate_chart(
    chart_type=ChartType.LINE,
    data=data,
    # ... other parameters
)
return self._altair_chart(chart, ...)
```

```168:169:lib/streamlit/elements/lib/built_in_chart_utils.py
def generate_chart(chart_type: ChartType, data: Data | None, ...):
    import altair as alt
```

The failure occurs when Altair attempts to process the chart data, specifically during the data transformation and chart generation process.

## 4. Potential Causes

The primary cause is a **breaking change in dependency interaction**:

### Altair 5.4.0 Major Changes:
- **Made pandas and NumPy optional dependencies** (per Altair 5.4.0 changelog)
- **Increased reliance on narwhals library** for data frame operations
- **Changed how data transformers handle native dataframes**

### Narwhals API Incompatibility:
- Altair 5.4.0/5.4.1 require narwhals API features that weren't stable in earlier versions
- The user's environment shows `narwhals >=1.5.2` but the problem versions need `narwhals>=2.0.1`

### Streamlit's Broad Dependency Specification:
```34:34:lib/setup.py
"altair>=4.0, <6",
```
This allows installation of the problematic Altair versions without ensuring compatible narwhals versions.

## 5. Contributing Factors

1. **Timing**: The issue occurred during Altair's transition to make pandas optional (5.4.0) and the subsequent fix attempts (5.4.1)

2. **Dependency Resolution**: Package managers may resolve to incompatible combinations because Streamlit doesn't directly depend on narwhals

3. **Transitive Dependencies**: The narwhals requirement comes through Altair, making the incompatibility indirect and harder to detect

## 6. Git History Review

From the Altair changelog analysis:
- **Altair 5.4.0**: "feat: make pandas and NumPy optional dependencies" and "Use more robust dtype comparisons, use Narwhals stable API"
- **Altair 5.4.1**: "fix: Pass native dataframe to data transformers" - attempted to fix the issue
- **Altair 5.5.0**: "Bump narwhals to v1.13.1" and further stability improvements

## 7. Conclusion

**Root Cause**: Altair versions 5.4.0 and 5.4.1 introduced breaking changes in their data handling that made them incompatible with older versions of the narwhals library. However, the dependency specifications didn't properly constrain this relationship, allowing package managers to install incompatible combinations.

**Evidence Supporting This Analysis**:
1. Marco Gorelli (an Altair contributor) specifically identified Altair 5.4.0 and 5.4.1 as problematic
2. The suggested fix is either to exclude these versions or ensure `narwhals>=2.0.1`
3. The Altair 5.4.0 changelog confirms major changes to data handling and narwhals integration
4. The issue affects Streamlit's built-in chart functions that rely on Altair's data processing

**The Fix**: Streamlit should either:
1. **Exclude the problematic versions**: `"altair>=4.0, <6, !=5.4.0, !=5.4.1"`
2. **Add narwhals constraint**: Add `"narwhals>=2.0.1"` when Altair 5.4.x is installed
3. **Bump minimum Altair version**: Use `"altair>=5.2.0, <6"` to avoid the problematic versions entirely

This is a classic example of a transitive dependency compatibility issue where the direct dependency (Altair) had breaking changes in its own dependencies (narwhals) that weren't properly constrained.
