### PR TITLE
feat(interrupt-rotation): track open PRs in adjacent repos

### DIFF
--- a/app/interrupt_rotation.py
+++ b/app/interrupt_rotation.py
@@ -16,6 +16,7 @@ from app.utils.interrupt_data import (
     get_bundle_size_metrics,
     get_flaky_tests,
     get_frontend_test_coverage_metrics,
+    get_monitored_repo_open_prs,
     get_playwright_test_count_metrics,
     get_python_test_coverage_metrics,
     get_wheel_size_metrics,
@@ -497,6 +498,39 @@ elif flaky_tests_df is not None:
             "Failures": st.column_config.NumberColumn("Failures"),
             "Workflow Run": st.column_config.LinkColumn("Last Workflow Run", display_text="Open"),
             "Last Failure Date": st.column_config.DatetimeColumn(format="distance"),
+        },
+    )
+st.divider()
+
+st.subheader(
+    "Open PRs in other important repos",
+    help="""
+Track open pull requests in adjacent Streamlit-maintained repos that may need interrupt rotation attention:
+- `streamlit/gallery`
+- `streamlit/component-template`
+- `streamlit/streamlit-bokeh`
+- `streamlit/streamlit-pdf`
+- `streamlit/agent-skills`
+""",
+)
+monitored_repo_prs_df = get_monitored_repo_open_prs(refresh_nonce=refresh_nonce)
+monitored_repo_prs_df = (
+    monitored_repo_prs_df[~monitored_repo_prs_df["Draft"]] if not monitored_repo_prs_df.empty else monitored_repo_prs_df
+)
+if monitored_repo_prs_df.empty:
+    st.success("No open PRs in the monitored repos right now.", icon="🎉")
+else:
+    st.dataframe(
+        monitored_repo_prs_df[["Title", "Repository", "URL", "Created", "Updated", "Author"]],
+        width="stretch",
+        hide_index=True,
+        column_config={
+            "Title": st.column_config.TextColumn("Title", width="large"),
+            "Repository": st.column_config.TextColumn("Repository", width="medium"),
+            "URL": st.column_config.LinkColumn("URL", display_text="Open"),
+            "Created": st.column_config.DatetimeColumn("Created", format="distance"),
+            "Updated": st.column_config.DatetimeColumn("Updated", format="distance"),
+            "Author": st.column_config.TextColumn("Author"),
         },
     )
 st.divider()

--- a/app/utils/github_utils.py
+++ b/app/utils/github_utils.py
@@ -672,19 +672,20 @@ def get_all_github_issues(
     return issues
 
 
-@st.cache_data(ttl=60 * 15, max_entries=24)  # cache for 15 minutes
+@st.cache_data(ttl=60 * 15, max_entries=128)  # cache for 15 minutes
 def get_all_github_prs(
     state: Literal["open", "closed", "all"] = "all",
     refresh_nonce: int = 0,
+    repo: str = "streamlit/streamlit",
 ) -> list[dict[str, Any]]:
-    """Paginate through all PRs in the streamlit/streamlit repo.
+    """Paginate through all PRs in a GitHub repo.
 
     Returns all PRs as a list of dicts.
     """
     _ = refresh_nonce  # Included to enable targeted cache busting from selected pages.
     prs = []
     state_param = f"state={state}" if state else ""
-    url: str | None = f"https://api.github.com/repos/streamlit/streamlit/pulls?{state_param}&per_page=100"
+    url: str | None = f"https://api.github.com/repos/{repo}/pulls?{state_param}&per_page=100"
 
     while url:
         try:

--- a/app/utils/interrupt_data.py
+++ b/app/utils/interrupt_data.py
@@ -31,6 +31,13 @@ from app.utils.github_utils import (
 DEFAULT_ISSUES_FOLDER = "issues"
 PATH_OF_SCRIPT = pathlib.Path(__file__).parent.parent.resolve()
 PATH_TO_ISSUES = pathlib.Path(PATH_OF_SCRIPT).parent.joinpath(DEFAULT_ISSUES_FOLDER).resolve()
+MONITORED_INTERRUPT_REPOS: tuple[str, ...] = (
+    "streamlit/gallery",
+    "streamlit/component-template",
+    "streamlit/streamlit-bokeh",
+    "streamlit/streamlit-pdf",
+    "streamlit/agent-skills",
+)
 
 
 def _issue_row(issue: dict[str, Any], labels: set[str]) -> dict[str, Any]:
@@ -59,6 +66,36 @@ def get_interrupt_data_snapshot(refresh_nonce: int = 0) -> tuple[list[dict[str, 
     issues = get_all_github_issues(state="open", refresh_nonce=refresh_nonce)
     prs = get_all_github_prs(state="open", refresh_nonce=refresh_nonce)
     return issues, prs
+
+
+@st.cache_data(ttl=60 * 10, max_entries=64, show_spinner=False)
+def get_monitored_repo_open_prs(refresh_nonce: int = 0) -> pd.DataFrame:
+    """Fetch open PRs from adjacent repos that the interrupt rotation should monitor."""
+    rows: list[dict[str, Any]] = []
+
+    for repo in MONITORED_INTERRUPT_REPOS:
+        repo_prs = get_all_github_prs(state="open", refresh_nonce=refresh_nonce, repo=repo)
+        rows.extend(
+            {
+                "Repository": repo,
+                "Title": pr["title"],
+                "URL": pr["html_url"],
+                "Created": pr["created_at"],
+                "Updated": pr["updated_at"],
+                "Author": pr.get("user", {}).get("login"),
+                "Draft": pr.get("draft", False),
+            }
+            for pr in repo_prs
+        )
+
+    monitored_prs = pd.DataFrame(rows)
+    if monitored_prs.empty:
+        return monitored_prs
+
+    return monitored_prs.sort_values(
+        by=["Updated", "Created", "Repository", "Title"],
+        ascending=[False, False, True, True],
+    ).reset_index(drop=True)
 
 
 def _build_interrupt_action_items(

--- a/tests/test_interrupt_data.py
+++ b/tests/test_interrupt_data.py
@@ -35,15 +35,18 @@ def _pr(
     title: str,
     labels: list[str],
     author: str,
+    repo: str = "streamlit/streamlit",
     draft: bool = False,
+    created_at: str = "2026-02-10T00:00:00+00:00",
+    updated_at: str = "2026-02-11T00:00:00+00:00",
     assignees: list[str] | None = None,
 ) -> dict:
     return {
         "number": number,
         "title": title,
-        "html_url": f"https://github.com/streamlit/streamlit/pull/{number}",
-        "created_at": "2026-02-10T00:00:00+00:00",
-        "updated_at": "2026-02-11T00:00:00+00:00",
+        "html_url": f"https://github.com/{repo}/pull/{number}",
+        "created_at": created_at,
+        "updated_at": updated_at,
         "draft": draft,
         "user": {"login": author},
         "labels": [{"name": label} for label in labels],
@@ -130,3 +133,64 @@ def test_build_interrupt_action_items_refresh_nonce_busts_cache(monkeypatch: pyt
 
     interrupt_data.build_interrupt_action_items(since, refresh_nonce=1)
     assert call_count["value"] == 2
+
+
+def test_get_monitored_repo_open_prs(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_payloads = {
+        "streamlit/gallery": [
+            _pr(
+                number=101,
+                repo="streamlit/gallery",
+                title="Gallery draft",
+                labels=[],
+                author="alice",
+                draft=True,
+                updated_at="2026-02-11T10:00:00+00:00",
+            )
+        ],
+        "streamlit/component-template": [],
+        "streamlit/streamlit-bokeh": [
+            _pr(
+                number=102,
+                repo="streamlit/streamlit-bokeh",
+                title="Bokeh cleanup",
+                labels=[],
+                author="bob",
+                updated_at="2026-02-09T10:00:00+00:00",
+            )
+        ],
+        "streamlit/streamlit-pdf": [
+            _pr(
+                number=103,
+                repo="streamlit/streamlit-pdf",
+                title="Pdf fix",
+                labels=[],
+                author="carol",
+                updated_at="2026-02-12T10:00:00+00:00",
+            )
+        ],
+        "streamlit/agent-skills": [],
+    }
+    calls: list[tuple[str, str, int]] = []
+
+    def fake_get_all_github_prs(
+        state: str = "all",
+        refresh_nonce: int = 0,
+        repo: str = "streamlit/streamlit",
+    ) -> list[dict]:
+        calls.append((repo, state, refresh_nonce))
+        return repo_payloads[repo]
+
+    monkeypatch.setattr(interrupt_data, "get_all_github_prs", fake_get_all_github_prs)
+    interrupt_data.get_monitored_repo_open_prs.clear()
+
+    monitored_prs = interrupt_data.get_monitored_repo_open_prs(refresh_nonce=3)
+
+    assert calls == [(repo, "open", 3) for repo in interrupt_data.MONITORED_INTERRUPT_REPOS]
+    assert list(monitored_prs["Title"]) == ["Pdf fix", "Gallery draft", "Bokeh cleanup"]
+    assert list(monitored_prs["Repository"]) == [
+        "streamlit/streamlit-pdf",
+        "streamlit/gallery",
+        "streamlit/streamlit-bokeh",
+    ]
+    assert list(monitored_prs["Draft"]) == [False, True, False]


### PR DESCRIPTION
Add a table to the interrupt rotation dashboard for non-draft PRs in the other Streamlit repos the team watches. This keeps the new section aligned with the existing PR tables while reusing the shared GitHub PR fetcher for repo-specific monitoring.