### PR TITLE
fix(interrupt-rotation): monitor st-issues and site PRs

### DIFF
--- a/app/interrupt_rotation.py
+++ b/app/interrupt_rotation.py
@@ -12,6 +12,7 @@ from app.utils.github_utils import (
     validate_issue_number,
 )
 from app.utils.interrupt_data import (
+    MONITORED_INTERRUPT_REPOS,
     build_interrupt_action_items,
     get_bundle_size_metrics,
     get_flaky_tests,
@@ -502,16 +503,14 @@ elif flaky_tests_df is not None:
     )
 st.divider()
 
+monitored_repos_help = "\n".join(f"- `{repo}`" for repo in MONITORED_INTERRUPT_REPOS)
+
 st.subheader(
-    "Open PRs in other important repos",
-    help="""
-Track open pull requests in adjacent Streamlit-maintained repos that may need interrupt rotation attention:
-- `streamlit/gallery`
-- `streamlit/component-template`
-- `streamlit/streamlit-bokeh`
-- `streamlit/streamlit-pdf`
-- `streamlit/agent-skills`
-""",
+    "Open PRs in important repos",
+    help=(
+        "Track open pull requests in Streamlit-maintained repos that may need interrupt rotation "
+        "attention:\n" + monitored_repos_help
+    ),
 )
 monitored_repo_prs_df = get_monitored_repo_open_prs(refresh_nonce=refresh_nonce)
 monitored_repo_prs_df = (

--- a/app/utils/interrupt_data.py
+++ b/app/utils/interrupt_data.py
@@ -37,6 +37,8 @@ MONITORED_INTERRUPT_REPOS: tuple[str, ...] = (
     "streamlit/streamlit-bokeh",
     "streamlit/streamlit-pdf",
     "streamlit/agent-skills",
+    "streamlit/st-issues",
+    "streamlit/site",
 )
 
 
@@ -70,7 +72,7 @@ def get_interrupt_data_snapshot(refresh_nonce: int = 0) -> tuple[list[dict[str, 
 
 @st.cache_data(ttl=60 * 10, max_entries=64, show_spinner=False)
 def get_monitored_repo_open_prs(refresh_nonce: int = 0) -> pd.DataFrame:
-    """Fetch open PRs from adjacent repos that the interrupt rotation should monitor."""
+    """Fetch open PRs from Streamlit-managed repos that the interrupt rotation should monitor."""
     rows: list[dict[str, Any]] = []
 
     for repo in MONITORED_INTERRUPT_REPOS:

--- a/tests/test_interrupt_data.py
+++ b/tests/test_interrupt_data.py
@@ -170,6 +170,26 @@ def test_get_monitored_repo_open_prs(monkeypatch: pytest.MonkeyPatch) -> None:
             )
         ],
         "streamlit/agent-skills": [],
+        "streamlit/st-issues": [
+            _pr(
+                number=104,
+                repo="streamlit/st-issues",
+                title="Issues cleanup",
+                labels=[],
+                author="dave",
+                updated_at="2026-02-13T10:00:00+00:00",
+            )
+        ],
+        "streamlit/site": [
+            _pr(
+                number=105,
+                repo="streamlit/site",
+                title="Docs refresh",
+                labels=[],
+                author="erin",
+                updated_at="2026-02-08T10:00:00+00:00",
+            )
+        ],
     }
     calls: list[tuple[str, str, int]] = []
 
@@ -187,10 +207,18 @@ def test_get_monitored_repo_open_prs(monkeypatch: pytest.MonkeyPatch) -> None:
     monitored_prs = interrupt_data.get_monitored_repo_open_prs(refresh_nonce=3)
 
     assert calls == [(repo, "open", 3) for repo in interrupt_data.MONITORED_INTERRUPT_REPOS]
-    assert list(monitored_prs["Title"]) == ["Pdf fix", "Gallery draft", "Bokeh cleanup"]
+    assert list(monitored_prs["Title"]) == [
+        "Issues cleanup",
+        "Pdf fix",
+        "Gallery draft",
+        "Bokeh cleanup",
+        "Docs refresh",
+    ]
     assert list(monitored_prs["Repository"]) == [
+        "streamlit/st-issues",
         "streamlit/streamlit-pdf",
         "streamlit/gallery",
         "streamlit/streamlit-bokeh",
+        "streamlit/site",
     ]
-    assert list(monitored_prs["Draft"]) == [False, True, False]
+    assert list(monitored_prs["Draft"]) == [False, False, True, False, False]


### PR DESCRIPTION
Add streamlit/st-issues and streamlit/site to the shared monitored repo list and derive the dashboard help text from that shared source so the UI and query stay aligned.

Extend the interrupt-data test coverage to include the new repos and expected ordering.