### PR TITLE
Add reproduction for issue #15618: selectbox reverts with format_func + custom classes

### DIFF
--- a/issues/gh-15618/app.py
+++ b/issues/gh-15618/app.py
@@ -1,0 +1,78 @@
+"""
+Reproduction for GitHub Issue #15618
+Title: selectbox always reverts to first item with format_func + custom classes
+URL: https://github.com/streamlit/streamlit/issues/15618
+
+Expected: Selecting an option in the selectbox keeps that selection
+Actual:   selectbox always reverts to the first option
+Reported version: 1.58.0
+"""
+import streamlit as st
+from dataclasses import dataclass
+from typing import NamedTuple
+
+st.title("Issue #15618: selectbox reverts with format_func")
+st.info("🔗 [View original issue](https://github.com/streamlit/streamlit/issues/15618)")
+
+st.header("Issue Overview")
+st.write("**Expected:** Selecting the second option keeps that selection.")
+st.error("**Actual (Bug):** selectbox always reverts to the first option when options "
+         "are dataclass/plain-class instances and `format_func` does a dict lookup on them.")
+
+st.divider()
+
+st.header("Bug Demonstration")
+st.write("""
+**Steps:**
+1. Click the selectbox below
+2. Select "two"
+3. Observe it reverts back to "one"
+""")
+
+@dataclass(frozen=True)
+class MyDataClass:
+    id: int
+    name: str
+
+a = MyDataClass(1, "one")
+b = MyDataClass(2, "two")
+x = {a: "I", b: "II"}
+
+def format_function(s):
+    print(x[s])
+    return s.name
+
+s = st.selectbox("selectbox (DataClass + format_func with dict lookup)", [a, b], format_func=format_function)
+st.write(f"**Selected:** {s.name}")
+
+st.divider()
+
+st.header("Comparison: NamedTuple (works correctly)")
+st.write("The same pattern with NamedTuple does NOT trigger the bug:")
+
+class MyNamedTuple(NamedTuple):
+    id: int
+    name: str
+
+c = MyNamedTuple(1, "one")
+d = MyNamedTuple(2, "two")
+y = {c: "I", d: "II"}
+
+def format_function_nt(s):
+    print(y[s])
+    return s.name
+
+s2 = st.selectbox("selectbox (NamedTuple + format_func with dict lookup)", [c, d], format_func=format_function_nt)
+st.write(f"**Selected:** {s2.name}")
+
+st.divider()
+
+st.header("Workaround")
+st.write("Remove the `print(x[s])` (or any expression that hashes the option object) "
+         "from `format_func`. The bug only triggers when `format_func` causes a side "
+         "effect that involves hashing the option objects.")
+
+st.divider()
+
+st.header("Environment")
+st.code(f"Streamlit version: {st.__version__}")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a reproduction app and detailed investigation notes for [streamlit/streamlit#15618](https://github.com/streamlit/streamlit/issues/15618) under `issues/gh-15618/` (`app.py` + `NOTES.md`).

## Reproduction status

**Bug confirmed and root-caused** on current `develop` (Streamlit 1.58.0).

- Occurs for **frozen dataclasses and plain classes** (not just plain classes); value-based `__hash__`/`__eq__` does **not** prevent it.
- `NamedTuple` is immune.
- Removing the dict lookup from `format_func` avoids it.

## Root cause

The widget *state* is correct ("two"), but `st.selectbox()` *returns* the default option ("one") to the script. `validate_and_sync_value_with_options` validates the stored selection by calling the user's `format_func` on it inside a broad `except Exception`. The stored value is a `deepcopy` of an instance of the *previous* rerun's class object (the script redefines the class each run); a dataclass's class-gated `__eq__` makes `x[s]` raise `KeyError`, which the broad except treats as "value not in options" and resets to index 0. `NamedTuple` uses value-based `tuple.__eq__`, so its lookup never raises.

See `issues/gh-15618/NOTES.md` for the full trace and a suggested fix direction.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f486a845-94a1-4349-942a-5771a8aeea80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f486a845-94a1-4349-942a-5771a8aeea80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

