### PR TITLE
feat(interrupt): surface open release version-bump PRs

### DIFF
--- a/app/interrupt_rotation.py
+++ b/app/interrupt_rotation.py
@@ -352,6 +352,33 @@ Every confirmed bug is expected to be labeled with a `priority:P{0,1,2,3,4}` lab
             )
 
         st.subheader(
+            "Open release PRs",
+            help="""
+Lists open automated release PRs (`[chore] Release vX.Y.Z` from `github-actions[bot]`).
+These back-merge the release branch into `develop` and only update version identifiers
+(`lib/pyproject.toml`, `uv.lock`, `frontend/package.json` and the frontend workspace packages).
+
+These PRs need a human approval before they become mergeable and are not assigned to anyone
+by default, so they can sit unnoticed. The Interrupt should make sure each one gets reviewed
+and merged.
+""",
+        )
+        release_prs_df = action_items["open_release_prs"]
+        if release_prs_df.empty:
+            st.success("Congrats, everything is done here!", icon="🎉")
+        else:
+            st.dataframe(
+                release_prs_df,
+                width="stretch",
+                hide_index=True,
+                column_config={
+                    "Title": st.column_config.TextColumn("Title", width="large"),
+                    "URL": st.column_config.LinkColumn("URL", display_text="Open"),
+                    "Created": st.column_config.DatetimeColumn("Created", format="distance"),
+                },
+            )
+
+        st.subheader(
             "Open Dependabot PRs",
             help="""
 Lists all open dependency update PRs from Dependabot. Please try to review and merge these PRs

--- a/app/utils/interrupt_data.py
+++ b/app/utils/interrupt_data.py
@@ -41,6 +41,10 @@ MONITORED_INTERRUPT_REPOS: tuple[str, ...] = (
     "streamlit/st-issues",
 )
 
+# Title prefix of the automated release PRs that bump the version identifiers
+# (for example "[chore] Release v1.61.0").
+RELEASE_PR_TITLE_PREFIX = "[chore] Release"
+
 
 def _issue_row(issue: dict[str, Any], labels: set[str]) -> dict[str, Any]:
     return {
@@ -115,6 +119,7 @@ def _build_interrupt_action_items(
     needs_approval_prs: list[dict[str, Any]] = []
     ready_for_review: list[dict[str, Any]] = []
     dependabot_prs: list[dict[str, Any]] = []
+    release_prs: list[dict[str, Any]] = []
 
     for issue in issues:
         if "pull_request" in issue:
@@ -191,6 +196,17 @@ def _build_interrupt_action_items(
                 }
             )
 
+        # Mirrors the GitHub search `is:pr "[chore] Release" author:app/github-actions is:open`,
+        # where `app/github-actions` is the `github-actions[bot]` login in the REST payload.
+        if author == "github-actions[bot]" and pr["title"].startswith(RELEASE_PR_TITLE_PREFIX):
+            release_prs.append(
+                {
+                    "Title": pr["title"],
+                    "URL": pr["html_url"],
+                    "Created": pr["created_at"],
+                }
+            )
+
         if not author or not is_community_author(author):
             continue
 
@@ -243,6 +259,7 @@ def _build_interrupt_action_items(
         "missing_labels_prs": pd.DataFrame(missing_label_prs),
         "prs_needing_approval": pd.DataFrame(needs_approval_prs),
         "open_dependabot_prs": pd.DataFrame(dependabot_prs),
+        "open_release_prs": pd.DataFrame(release_prs),
         "community_prs_ready_for_review": pd.DataFrame(ready_for_review),
         "confirmed_bugs_without_repro": pd.DataFrame(bugs_without_repro),
     }
@@ -647,3 +664,9 @@ def get_open_dependabot_prs(refresh_nonce: int = 0) -> pd.DataFrame:
     """Get open Dependabot PRs without 'do-not-merge' label."""
     data = build_interrupt_action_items(date.today(), refresh_nonce=refresh_nonce)
     return data["open_dependabot_prs"].copy()
+
+
+def get_open_release_prs(refresh_nonce: int = 0) -> pd.DataFrame:
+    """Get open automated release PRs that bump the version identifiers."""
+    data = build_interrupt_action_items(date.today(), refresh_nonce=refresh_nonce)
+    return data["open_release_prs"].copy()

--- a/tests/test_interrupt_data.py
+++ b/tests/test_interrupt_data.py
@@ -97,6 +97,9 @@ def test_build_interrupt_action_items_shapes(monkeypatch: pytest.MonkeyPatch) ->
             draft=True,
         ),
         _pr(number=15, title="Internal PR", labels=["change:enhancement", "impact:users"], author="sfc-gh-bnisco"),
+        _pr(number=16, title="[chore] Release v1.61.0", labels=["change:chore"], author="github-actions[bot]"),
+        _pr(number=17, title="[snapshots] Update E2E snapshots for #15693", labels=[], author="github-actions[bot]"),
+        _pr(number=18, title="[chore] Release v1.62.0", labels=[], author="sfc-gh-release-manager"),
     ]
 
     monkeypatch.setattr(interrupt_data, "get_interrupt_data_snapshot", lambda refresh_nonce=0: (issues, prs))
@@ -120,6 +123,9 @@ def test_build_interrupt_action_items_shapes(monkeypatch: pytest.MonkeyPatch) ->
     assert set(data["prs_needing_approval"]["Title"]) == {"Needs approval"}
     assert set(data["community_prs_ready_for_review"]["Title"]) == {"Needs approval", "Ready for review"}
     assert set(data["open_dependabot_prs"]["Title"]) == {"Dependabot update"}
+    # Only `github-actions[bot]` PRs with the release title prefix count: the snapshot-update bot
+    # PR and the human-authored release PR are both excluded.
+    assert set(data["open_release_prs"]["Title"]) == {"[chore] Release v1.61.0"}
 
 
 def test_build_interrupt_action_items_refresh_nonce_busts_cache(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
The automated `[chore] Release vX.Y.Z` PRs from `github-actions[bot]` appeared nowhere on the Interrupt dashboard: the Dependabot bucket only matches `dependabot[bot]`, and every community-PR view drops bot authors via `is_community_author`. Those PRs need a human approval to become mergeable and have no assignee, so they can sit unnoticed for days.

## Changes

- **`app/utils/interrupt_data.py`** — new `open_release_prs` bucket in `_build_interrupt_action_items`, filtering the open-PR snapshot the page already fetches on `author == "github-actions[bot]"` and a `[chore] Release` title prefix. Costs no extra API calls. Adds a `RELEASE_PR_TITLE_PREFIX` constant and a `get_open_release_prs()` wrapper, matching the one-getter-per-bucket pattern in the file.
- **`app/interrupt_rotation.py`** — "Open release PRs" table in the Action required list, directly above the Dependabot table since both are bot PRs from the same snapshot.
- **`tests/test_interrupt_data.py`** — fixtures covering the match plus both near-misses.

The filter mirrors the GitHub search [`is:pr "[chore] Release" author:app/github-actions is:open`](https://github.com/streamlit/streamlit/pulls?q=is%3Apr+%22%5Bchore%5D+Release%22+author%3Aapp%2Fgithub-actions+is%3Aopen) so the dashboard and that saved search always agree.

## Notes on two deliberate choices

**No staleness or SLA chip.** Recent release PRs stayed open v1.60.0 23h, v1.58.0 5d, v1.57.0 3d, v1.56.0 1.3d, v1.55.0 1d, v1.54.0 6d. Any threshold under a week would read red on a healthy release and train people to ignore the section. `Created` with `format="distance"` carries the age without asserting a judgment.

**The tooltip makes no claim about merge timing.** It documents what the PR is (back-merge of the release branch into `develop`, version identifiers only) and that the Interrupt owns getting it reviewed and merged. If the actual rule is "merge as soon as CI is green" or "only after the release ships," that is a one-line edit — I did not want to document the release process wrongly in a tooltip people read as procedure.

Snapshot-update PRs (`[snapshots] Update E2E snapshots for #NNNNN`, same bot) are intentionally out of scope. There is one currently open since Jul 22; adding it later is a second `if` in the same loop.

## Testing

- `uv run pytest tests/test_interrupt_data.py` — 3 passed
- `make check` — ruff, ruff format, ty, mypy all clean
- Ran the bucket logic against the live 212 open PRs in `streamlit/streamlit`: one row, `#16329 [chore] Release v1.61.0`, identical to what the GitHub search returns
- Did not launch the app for a visual check; the render block mirrors the adjacent Dependabot table

🤖 Generated with [Claude Code](https://claude.com/claude-code)